### PR TITLE
Fixed issue with local (non arm) compilation

### DIFF
--- a/test/depthwise-microkernel-tester.h
+++ b/test/depthwise-microkernel-tester.h
@@ -247,12 +247,21 @@ class DepthwiseMicrokernelTester {
           (outputStride() - channels()) * sizeof(uint8_t),
           &quantizationParams);
       } else {
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
         q8dw_ukernel_25c8__neon(
           channels(), width(),
           indirectInput.data(), packedWeights.data(), outacc32.data(), output.data(),
           kernelHeight() * subsampling() * sizeof(void*),
           (outputStride() - channels()) * sizeof(uint8_t),
           &quantizationParams);
+#else
+        q8dw(
+          channels(), width(),
+          indirectInput.data(), packedWeights.data(), output.data(),
+          kernelHeight() * subsampling() * sizeof(void*),
+          (outputStride() - channels()) * sizeof(uint8_t),
+          &quantizationParams);
+#endif
       }
 
       for (size_t x = 0; x < width(); x++) {


### PR DESCRIPTION
q8dw_ukernel_25c8__neon does not exist when compiling on pc, causing a compilation error:

> CMakeFiles/q8dw-test.dir/test/q8dw.cc.o: In function `DepthwiseMicrokernelTester::test(void (*)(unsigned long, unsigned long, unsigned char const**, void const*, unsigned char*, unsigned long, unsigned long, qnnp_conv_quantization_params const*)) const':
> q8dw.cc:(.text._ZNK26DepthwiseMicrokernelTester4testEPFvmmPPKhPKvPhmmPK29qnnp_conv_quantization_paramsE[_ZNK26DepthwiseMicrokernelTester4testEPFvmmPPKhPKvPhmmPK29qnnp_conv_quantization_paramsE]+0x14ba): undefined reference to `q8dw_ukernel_25c8__neon'
> collect2: error: ld returned 1 exit status
> CMakeFiles/q8dw-test.dir/build.make:90: recipe for target 'q8dw-test' failed
