### PR TITLE
fix comments and temproraily disabling 9c8 neonS

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -62,7 +62,7 @@ static void init(void) {
       break;
   }
   qnnp_params.q8dw9 = (struct q8dw_parameters) {
-      .dw = q8dw_ukernel_9c8__aarch32_neon,
+      .dw = q8dw_ukernel_9c8__neon,
       .cr = 8,
   };
   qnnp_params.q8dw25 = (struct q8dw_multipass_parameters) {

--- a/src/q8dw/9c8-aarch32-neon.S
+++ b/src/q8dw/9c8-aarch32-neon.S
@@ -10,7 +10,7 @@
 
 .syntax unified
 
-# void q8dw_ukernel_9c8__neon(
+# void q8dw_ukernel_9c8__aarch32_neon(
 #     size_t channels,
 #     size_t output_width,
 #     const uint8_t** input,
@@ -25,7 +25,7 @@ BEGIN_FUNCTION q8dw_ukernel_9c8__aarch32_neon
 	.arch armv7-a
 	.fpu neon
 #endif
-	
+
 	# Load params
 	# - r12 = quantization_params
 	LDR r12, [sp, 12]


### PR DESCRIPTION
assembly path of 9c8 kernel is having trouble with `darwin-x86_64/bin/clang++`. Disabling it for now.

@Maratyszcza please take a look later