### PR TITLE
syntax for 9c8 aarch32 kernel

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -62,7 +62,7 @@ static void init(void) {
       break;
   }
   qnnp_params.q8dw9 = (struct q8dw_parameters) {
-      .dw = q8dw_ukernel_9c8__neon,
+      .dw = q8dw_ukernel_9c8__aarch32_neon,
       .cr = 8,
   };
   qnnp_params.q8dw25 = (struct q8dw_multipass_parameters) {

--- a/src/q8dw/9c8-aarch32-neon.S
+++ b/src/q8dw/9c8-aarch32-neon.S
@@ -33,8 +33,8 @@ BEGIN_FUNCTION q8dw_ukernel_9c8__aarch32_neon
 	PUSH {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	VPUSH {d8-d15}
 
-	STR r0, [sp, -8]
-	STR r3, [sp, -4]
+	STR r0, [sp, #-8]
+	STR r3, [sp, #-4]
 
 	MOV r4, 2
 
@@ -82,7 +82,7 @@ BEGIN_FUNCTION q8dw_ukernel_9c8__aarch32_neon
 
 	# Load c:
 	# - r0 = c = channels
-	LDR r0, [sp, -8]
+	LDR r0, [sp, #-8]
 
 	# Load i0, i1, i2, i3, i4, i5, i6, i7, i8
 	# - r4 = i0
@@ -105,7 +105,7 @@ BEGIN_FUNCTION q8dw_ukernel_9c8__aarch32_neon
 
 	# Load w:
 	# - r3 = w = weights
-	LDR r3, [sp, -4]
+	LDR r3, [sp, #-4]
 
 	BLO 2f
 


### PR DESCRIPTION
Fix syntax for 9c8 aarch 32 and enabling it back