### PR TITLE
Per channel quant

### DIFF
--- a/src/q8gemm/4x8-neon.c
+++ b/src/q8gemm/4x8-neon.c
@@ -362,3 +362,359 @@ void q8gemm_ukernel_4x8__neon(
     }
   }
 }
+
+void q8gemm_per_channel_ukernel_4x8__neon(
+    size_t mr,
+    size_t nr,
+    size_t k,
+    const uint8_t* restrict a,
+    size_t a_stride,
+    const void* restrict w,
+    uint8_t* restrict c,
+    size_t c_stride,
+    const union qnnp_conv_quantization_params quantization_params[restrict static 1],
+    size_t kernel_quantization_params_offset)
+{
+  int32x4_t vacc0x0123 = vld1q_s32(w); w = (const void*) ((uintptr_t) w + 16);
+  int32x4_t vacc0x4567 = vld1q_s32(w); w = (const void*) ((uintptr_t) w + 16);
+  int32x4_t vacc1x0123 = vacc0x0123;
+  int32x4_t vacc1x4567 = vacc0x4567;
+  int32x4_t vacc2x0123 = vacc0x0123;
+  int32x4_t vacc2x4567 = vacc0x4567;
+  int32x4_t vacc3x0123 = vacc0x0123;
+  int32x4_t vacc3x4567 = vacc0x4567;
+
+  const uint8_t* a0 = a;
+  const uint8_t* a1 = (const uint8_t*) ((uintptr_t) a0 + a_stride);
+  if (mr < 2) {
+    a1 = a0;
+  }
+  const uint8_t* a2 = (const uint8_t*) ((uintptr_t) a1 + a_stride);
+  if (mr <= 2) {
+    a2 = a1;
+  }
+  const uint8_t* a3 = (const uint8_t*) ((uintptr_t) a2 + a_stride);
+  if (mr != 4) {
+    a3 = a2;
+  }
+
+  const uint8x8_t vb_zero_point = vld1_u8((const uint8_t*) &quantization_params->neon.kernel_zero_point_v[kernel_quantization_params_offset]);
+  for (; k >= 8; k -= 8) {
+    const uint8x8_t va0 = vld1_u8(a0); a0 += 8;
+    const int16x8_t vxa0 = vreinterpretq_s16_u16(vmovl_u8(va0));
+    const uint8x8_t va1 = vld1_u8(a1); a1 += 8;
+    const int16x8_t vxa1 = vreinterpretq_s16_u16(vmovl_u8(va1));
+    const uint8x8_t va2 = vld1_u8(a2); a2 += 8;
+    const int16x8_t vxa2 = vreinterpretq_s16_u16(vmovl_u8(va2));
+    const uint8x8_t va3 = vld1_u8(a3); a3 += 8;
+    const int16x8_t vxa3 = vreinterpretq_s16_u16(vmovl_u8(va3));
+
+    const uint8x8_t vb01234567c0 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c0 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c0, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa0), 0);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa0), 0);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa1), 0);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa1), 0);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa2), 0);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa2), 0);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa3), 0);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa3), 0);
+
+    const uint8x8_t vb01234567c1 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c1 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c1, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa0), 1);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa0), 1);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa1), 1);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa1), 1);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa2), 1);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa2), 1);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa3), 1);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa3), 1);
+
+    const uint8x8_t vb01234567c2 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c2 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c2, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa0), 2);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa0), 2);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa1), 2);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa1), 2);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa2), 2);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa2), 2);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa3), 2);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa3), 2);
+
+    const uint8x8_t vb01234567c3 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c3 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c3, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa0), 3);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa0), 3);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa1), 3);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa1), 3);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa2), 3);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa2), 3);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa3), 3);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa3), 3);
+
+    const uint8x8_t vb01234567c4 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c4 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c4, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa0), 0);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa0), 0);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa1), 0);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa1), 0);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa2), 0);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa2), 0);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa3), 0);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa3), 0);
+
+    const uint8x8_t vb01234567c5 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c5 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c5, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa0), 1);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa0), 1);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa1), 1);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa1), 1);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa2), 1);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa2), 1);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa3), 1);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa3), 1);
+
+    const uint8x8_t vb01234567c6 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c6 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c6, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa0), 2);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa0), 2);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa1), 2);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa1), 2);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa2), 2);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa2), 2);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa3), 2);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa3), 2);
+
+    const uint8x8_t vb01234567c7 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c7 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c7, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c7), vget_high_s16(vxa0), 3);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c7), vget_high_s16(vxa0), 3);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c7), vget_high_s16(vxa1), 3);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c7), vget_high_s16(vxa1), 3);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c7), vget_high_s16(vxa2), 3);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c7), vget_high_s16(vxa2), 3);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c7), vget_high_s16(vxa3), 3);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c7), vget_high_s16(vxa3), 3);
+  }
+  if (k != 0) {
+    const size_t a_predecrement = 8 - k;
+    const int64x1_t va_shift = vmov_n_s64(-8 * a_predecrement);
+    const uint8x8_t va0 = vreinterpret_u8_u64(vshl_u64(vreinterpret_u64_u8(vld1_u8(a0 - a_predecrement)), va_shift));
+    const int16x8_t vxa0 = vreinterpretq_s16_u16(vmovl_u8(va0));
+    const uint8x8_t va1 = vreinterpret_u8_u64(vshl_u64(vreinterpret_u64_u8(vld1_u8(a1 - a_predecrement)), va_shift));
+    const int16x8_t vxa1 = vreinterpretq_s16_u16(vmovl_u8(va1));
+    const uint8x8_t va2 = vreinterpret_u8_u64(vshl_u64(vreinterpret_u64_u8(vld1_u8(a2 - a_predecrement)), va_shift));
+    const int16x8_t vxa2 = vreinterpretq_s16_u16(vmovl_u8(va2));
+    const uint8x8_t va3 = vreinterpret_u8_u64(vshl_u64(vreinterpret_u64_u8(vld1_u8(a3 - a_predecrement)), va_shift));
+    const int16x8_t vxa3 = vreinterpretq_s16_u16(vmovl_u8(va3));
+
+    const uint8x8_t vb01234567c0 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+    const int16x8_t vxb01234567c0 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c0, vb_zero_point));
+
+    vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa0), 0);
+    vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa0), 0);
+    vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa1), 0);
+    vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa1), 0);
+    vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa2), 0);
+    vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa2), 0);
+    vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c0), vget_low_s16(vxa3), 0);
+    vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c0), vget_low_s16(vxa3), 0);
+
+    if (k >= 2) {
+      const uint8x8_t vb01234567c1 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+      const int16x8_t vxb01234567c1 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c1, vb_zero_point));
+
+      vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa0), 1);
+      vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa0), 1);
+      vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa1), 1);
+      vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa1), 1);
+      vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa2), 1);
+      vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa2), 1);
+      vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c1), vget_low_s16(vxa3), 1);
+      vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c1), vget_low_s16(vxa3), 1);
+
+      if (k >= 3) {
+        const uint8x8_t vb01234567c2 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+        const int16x8_t vxb01234567c2 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c2, vb_zero_point));
+
+        vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa0), 2);
+        vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa0), 2);
+        vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa1), 2);
+        vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa1), 2);
+        vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa2), 2);
+        vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa2), 2);
+        vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c2), vget_low_s16(vxa3), 2);
+        vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c2), vget_low_s16(vxa3), 2);
+
+        if (k >= 4) {
+          const uint8x8_t vb01234567c3 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+          const int16x8_t vxb01234567c3 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c3, vb_zero_point));
+
+          vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa0), 3);
+          vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa0), 3);
+          vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa1), 3);
+          vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa1), 3);
+          vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa2), 3);
+          vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa2), 3);
+          vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c3), vget_low_s16(vxa3), 3);
+          vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c3), vget_low_s16(vxa3), 3);
+
+          if (k >= 5) {
+            const uint8x8_t vb01234567c4 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+            const int16x8_t vxb01234567c4 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c4, vb_zero_point));
+
+            vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa0), 0);
+            vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa0), 0);
+            vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa1), 0);
+            vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa1), 0);
+            vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa2), 0);
+            vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa2), 0);
+            vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c4), vget_high_s16(vxa3), 0);
+            vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c4), vget_high_s16(vxa3), 0);
+
+            if (k >= 6) {
+              const uint8x8_t vb01234567c5 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+              const int16x8_t vxb01234567c5 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c5, vb_zero_point));
+
+              vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa0), 1);
+              vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa0), 1);
+              vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa1), 1);
+              vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa1), 1);
+              vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa2), 1);
+              vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa2), 1);
+              vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c5), vget_high_s16(vxa3), 1);
+              vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c5), vget_high_s16(vxa3), 1);
+
+              if (k >= 7) {
+                const uint8x8_t vb01234567c6 = vld1_u8(w); w = (const void*) ((uintptr_t) w + 8);
+                const int16x8_t vxb01234567c6 = vreinterpretq_s16_u16(vsubl_u8(vb01234567c6, vb_zero_point));
+
+                vacc0x0123 = vmlal_lane_s16(vacc0x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa0), 2);
+                vacc0x4567 = vmlal_lane_s16(vacc0x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa0), 2);
+                vacc1x0123 = vmlal_lane_s16(vacc1x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa1), 2);
+                vacc1x4567 = vmlal_lane_s16(vacc1x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa1), 2);
+                vacc2x0123 = vmlal_lane_s16(vacc2x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa2), 2);
+                vacc2x4567 = vmlal_lane_s16(vacc2x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa2), 2);
+                vacc3x0123 = vmlal_lane_s16(vacc3x0123, vget_low_s16(vxb01234567c6), vget_high_s16(vxa3), 2);
+                vacc3x4567 = vmlal_lane_s16(vacc3x4567, vget_high_s16(vxb01234567c6), vget_high_s16(vxa3), 2);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const int32x4_t vmultiplier0x0123 = vld1q_s32(&quantization_params->neon.multiplier_v[kernel_quantization_params_offset]);
+  const int32x4_t vmultiplier0x4567 = vld1q_s32(&quantization_params->neon.multiplier_v[kernel_quantization_params_offset + 4]);
+  vacc0x0123 = vqrdmulhq_s32(vacc0x0123, vmultiplier0x0123);
+  vacc0x4567 = vqrdmulhq_s32(vacc0x4567, vmultiplier0x4567);
+  vacc1x0123 = vqrdmulhq_s32(vacc1x0123, vmultiplier0x0123);
+  vacc1x4567 = vqrdmulhq_s32(vacc1x4567, vmultiplier0x4567);
+  vacc2x0123 = vqrdmulhq_s32(vacc2x0123, vmultiplier0x0123);
+  vacc2x4567 = vqrdmulhq_s32(vacc2x4567, vmultiplier0x4567);
+  vacc3x0123 = vqrdmulhq_s32(vacc3x0123, vmultiplier0x0123);
+  vacc3x4567 = vqrdmulhq_s32(vacc3x4567, vmultiplier0x4567);
+
+  const int32x4_t vright_shift_0x0123 = vld1q_s32(&quantization_params->neon.right_shift_v[kernel_quantization_params_offset]);
+  const int32x4_t vright_shift_0x4567 = vld1q_s32(&quantization_params->neon.right_shift_v[kernel_quantization_params_offset + 4]);
+  const int32x4_t vzero_shift_mask_0x0123 = vreinterpretq_s32_u32(vceqq_s32(vright_shift_0x0123, vmovq_n_s32(0)));
+  const int32x4_t vzero_shift_mask_0x4567 = vreinterpretq_s32_u32(vceqq_s32(vright_shift_0x4567, vmovq_n_s32(0)));
+  vacc0x0123 = vsraq_n_s32(vacc0x0123, vbicq_s32(vacc0x0123, vzero_shift_mask_0x0123), 31);
+  vacc0x4567 = vsraq_n_s32(vacc0x4567, vbicq_s32(vacc0x4567, vzero_shift_mask_0x4567), 31);
+  vacc1x0123 = vsraq_n_s32(vacc1x0123, vbicq_s32(vacc1x0123, vzero_shift_mask_0x0123), 31);
+  vacc1x4567 = vsraq_n_s32(vacc1x4567, vbicq_s32(vacc1x4567, vzero_shift_mask_0x4567), 31);
+  vacc2x0123 = vsraq_n_s32(vacc2x0123, vbicq_s32(vacc2x0123, vzero_shift_mask_0x0123), 31);
+  vacc2x4567 = vsraq_n_s32(vacc2x4567, vbicq_s32(vacc2x4567, vzero_shift_mask_0x4567), 31);
+  vacc3x0123 = vsraq_n_s32(vacc3x0123, vbicq_s32(vacc3x0123, vzero_shift_mask_0x0123), 31);
+  vacc3x4567 = vsraq_n_s32(vacc3x4567, vbicq_s32(vacc3x4567, vzero_shift_mask_0x4567), 31);
+
+  vacc0x0123 = vrshlq_s32(vacc0x0123, vright_shift_0x0123);
+  vacc0x4567 = vrshlq_s32(vacc0x4567, vright_shift_0x4567);
+  vacc1x0123 = vrshlq_s32(vacc1x0123, vright_shift_0x0123);
+  vacc1x4567 = vrshlq_s32(vacc1x4567, vright_shift_0x4567);
+  vacc2x0123 = vrshlq_s32(vacc2x0123, vright_shift_0x0123);
+  vacc2x4567 = vrshlq_s32(vacc2x4567, vright_shift_0x4567);
+  vacc3x0123 = vrshlq_s32(vacc3x0123, vright_shift_0x0123);
+  vacc3x4567 = vrshlq_s32(vacc3x4567, vright_shift_0x4567);
+
+  const int16x8_t voutput_zero_point = vld1q_dup_s16(&quantization_params->neon.output_zero_point);
+#ifdef __aarch64__
+  const int16x8_t vacc0x01234567 = vqaddq_s16(vqmovn_high_s32(vqmovn_s32(vacc0x0123), vacc0x4567), voutput_zero_point);
+  const int16x8_t vacc1x01234567 = vqaddq_s16(vqmovn_high_s32(vqmovn_s32(vacc1x0123), vacc1x4567), voutput_zero_point);
+  const int16x8_t vacc2x01234567 = vqaddq_s16(vqmovn_high_s32(vqmovn_s32(vacc2x0123), vacc2x4567), voutput_zero_point);
+  const int16x8_t vacc3x01234567 = vqaddq_s16(vqmovn_high_s32(vqmovn_s32(vacc3x0123), vacc3x4567), voutput_zero_point);
+
+  uint8x16_t vout0x01234567_1x01234567 = vqmovun_high_s16(vqmovun_s16(vacc0x01234567), vacc1x01234567);
+  uint8x16_t vout2x01234567_3x01234567 = vqmovun_high_s16(vqmovun_s16(vacc2x01234567), vacc3x01234567);
+#else
+  const int16x8_t vacc0x01234567 = vqaddq_s16(vcombine_s16(vqmovn_s32(vacc0x0123), vqmovn_s32(vacc0x4567)), voutput_zero_point);
+  const int16x8_t vacc1x01234567 = vqaddq_s16(vcombine_s16(vqmovn_s32(vacc1x0123), vqmovn_s32(vacc1x4567)), voutput_zero_point);
+  const int16x8_t vacc2x01234567 = vqaddq_s16(vcombine_s16(vqmovn_s32(vacc2x0123), vqmovn_s32(vacc2x4567)), voutput_zero_point);
+  const int16x8_t vacc3x01234567 = vqaddq_s16(vcombine_s16(vqmovn_s32(vacc3x0123), vqmovn_s32(vacc3x4567)), voutput_zero_point);
+
+  uint8x16_t vout0x01234567_1x01234567 = vcombine_u8(vqmovun_s16(vacc0x01234567), vqmovun_s16(vacc1x01234567));
+  uint8x16_t vout2x01234567_3x01234567 = vcombine_u8(vqmovun_s16(vacc2x01234567), vqmovun_s16(vacc3x01234567));
+#endif
+  const uint8x16_t voutput_min = vld1q_dup_u8(&quantization_params->neon.output_min);
+  const uint8x16_t voutput_max = vld1q_dup_u8(&quantization_params->neon.output_max);
+
+  vout0x01234567_1x01234567 = vmaxq_u8(vout0x01234567_1x01234567, voutput_min);
+  vout2x01234567_3x01234567 = vmaxq_u8(vout2x01234567_3x01234567, voutput_min);
+  vout0x01234567_1x01234567 = vminq_u8(vout0x01234567_1x01234567, voutput_max);
+  vout2x01234567_3x01234567 = vminq_u8(vout2x01234567_3x01234567, voutput_max);
+
+  uint8_t* c0 = c;
+  uint8_t* c1 = (uint8_t*) ((uintptr_t) c0 + c_stride);
+  if (mr < 2) {
+    c1 = c0;
+  }
+  uint8_t* c2 = (uint8_t*) ((uintptr_t) c1 + c_stride);
+  if (mr <= 2) {
+    c2 = c1;
+  }
+  uint8_t* c3 = (uint8_t*) ((uintptr_t) c2 + c_stride);
+  if (mr != 4) {
+    c3 = c2;
+  }
+  if (nr == 8) {
+    vst1_u8(c0, vget_low_u8(vout0x01234567_1x01234567));
+    vst1_u8(c1, vget_high_u8(vout0x01234567_1x01234567));
+    vst1_u8(c2, vget_low_u8(vout2x01234567_3x01234567));
+    vst1_u8(c3, vget_high_u8(vout2x01234567_3x01234567));
+  } else {
+    if (nr >= 4) {
+      vst1q_lane_u32(__builtin_assume_aligned(c0, 1), vreinterpretq_u32_u8(vout0x01234567_1x01234567), 0); c0 += 4;
+      vst1q_lane_u32(__builtin_assume_aligned(c1, 1), vreinterpretq_u32_u8(vout0x01234567_1x01234567), 2); c1 += 4;
+      vst1q_lane_u32(__builtin_assume_aligned(c2, 1), vreinterpretq_u32_u8(vout2x01234567_3x01234567), 0); c2 += 4;
+      vst1q_lane_u32(__builtin_assume_aligned(c3, 1), vreinterpretq_u32_u8(vout2x01234567_3x01234567), 2); c3 += 4;
+      vout0x01234567_1x01234567 = vextq_u8(vout0x01234567_1x01234567, vout0x01234567_1x01234567, 4);
+      vout2x01234567_3x01234567 = vextq_u8(vout2x01234567_3x01234567, vout2x01234567_3x01234567, 4);
+      nr -= 4;
+    }
+    if (nr >= 2) {
+      vst1q_lane_u16(__builtin_assume_aligned(c0, 1), vreinterpretq_u16_u8(vout0x01234567_1x01234567), 0); c0 += 2;
+      vst1q_lane_u16(__builtin_assume_aligned(c1, 1), vreinterpretq_u16_u8(vout0x01234567_1x01234567), 4); c1 += 2;
+      vst1q_lane_u16(__builtin_assume_aligned(c2, 1), vreinterpretq_u16_u8(vout2x01234567_3x01234567), 0); c2 += 2;
+      vst1q_lane_u16(__builtin_assume_aligned(c3, 1), vreinterpretq_u16_u8(vout2x01234567_3x01234567), 4); c3 += 2;
+      vout0x01234567_1x01234567 = vextq_u8(vout0x01234567_1x01234567, vout0x01234567_1x01234567, 2);
+      vout2x01234567_3x01234567 = vextq_u8(vout2x01234567_3x01234567, vout2x01234567_3x01234567, 2);
+      nr -= 2;
+    }
+    if (nr != 0) {
+      vst1q_lane_u8(c0, vout0x01234567_1x01234567, 0);
+      vst1q_lane_u8(c1, vout0x01234567_1x01234567, 8);
+      vst1q_lane_u8(c2, vout2x01234567_3x01234567, 0);
+      vst1q_lane_u8(c3, vout2x01234567_3x01234567, 8);
+    }
+  }
+}

--- a/src/qnnpack/params.h
+++ b/src/qnnpack/params.h
@@ -145,6 +145,9 @@ union qnnp_conv_quantization_params {
     int16_t output_zero_point;
     uint8_t output_max;
     uint8_t output_min;
+    uint8_t* kernel_zero_point_v;
+    int32_t* multiplier_v;
+    int32_t* right_shift_v;
   } neon;
 #endif /* CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 */
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
@@ -274,6 +277,18 @@ typedef void (*q8gemm_ukernel_function)(
     uint8_t* c,
     size_t c_stride,
     const union qnnp_conv_quantization_params* quantization_params);
+
+typedef void (*q8gemm_per_channel_ukernel_function)(
+    size_t mr,
+    size_t nr,
+    size_t k,
+    const uint8_t* a,
+    size_t a_stride,
+    const void* w,
+    uint8_t* c,
+    size_t c_stride,
+    const union qnnp_conv_quantization_params* quantization_params,
+    size_t kernel_quantization_params_offset);
 
 typedef void (*q8conv_ukernel_function)(
     size_t mr,

--- a/src/qnnpack/q8gemm.h
+++ b/src/qnnpack/q8gemm.h
@@ -43,6 +43,21 @@ DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_8x8__aarch64_neon)
 DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_2x4c8__sse2)
 DECLARE_Q8GEMM_UKERNEL_FUNCTION(q8gemm_ukernel_4x4c2__sse2)
 
+#define DECLARE_Q8GEMM_PER_CHANNEL_UKERNEL_FUNCTION(fn_name)                      \
+  QNNP_INTERNAL void fn_name(                                         \
+      size_t mr,                                                      \
+      size_t nr,                                                      \
+      size_t k,                                                       \
+      const uint8_t* a,                                               \
+      size_t a_stride,                                                \
+      const void* w,                                                  \
+      uint8_t* c,                                                     \
+      size_t c_stride,                                                \
+      const union qnnp_conv_quantization_params* quantization_params, \
+      size_t kernel_quantization_params_offset);
+
+DECLARE_Q8GEMM_PER_CHANNEL_UKERNEL_FUNCTION(q8gemm_per_channel_ukernel_4x8__neon)
+
 #define DECLARE_Q8GEMM_XZP_UKERNEL_FUNCTION(fn_name) \
   QNNP_INTERNAL void fn_name(                        \
       size_t mr,                                     \

--- a/src/qnnpack/requantization.h
+++ b/src/qnnpack/requantization.h
@@ -197,6 +197,110 @@ static inline union qnnp_conv_quantization_params qnnp_compute_conv_quantization
   return params;
 }
 
+static inline union qnnp_conv_quantization_params qnnp_compute_conv_quantization_params_per_channel(
+  uint8_t input_zero_point,
+  size_t kernel_params_size, // should be identical to group_output_channels
+  uint8_t* kernel_zero_point_v,
+  const float* scale_v,
+  int32_t* multiplier_v,         // pre-allocated in operator-create
+  int32_t* right_shift_v,        // pre-allocated in operator-create
+  uint8_t output_zero_point,
+  uint8_t output_min,
+  uint8_t output_max)
+{
+  const float scale = *scale_v;
+  const uint8_t kernel_zero_point = *kernel_zero_point_v;
+  /* Compute requantization parameters */
+  const uint32_t scale_bits = fp32_to_bits(scale);
+
+  /* Multiplier is in [0x40000000, 0x7FFFFF80] range */
+  const int32_t multiplier = (int32_t)(((scale_bits & UINT32_C(0x007FFFFF)) | UINT32_C(0x00800000)) << 7);
+  assert(multiplier >= INT32_C(0x40000000));
+  assert(multiplier <= INT32_C(0x7FFFFF80));
+
+  /* Shift is in [0, 31] range */
+  const int32_t shift = 127 + 31 - 32 - (fp32_to_bits(scale) >> 23);
+  assert(shift >= 0);
+  assert(shift < 32);
+
+  union qnnp_conv_quantization_params params;
+  #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+    const uint32_t remainder_mask = (UINT32_C(1) << shift) - UINT32_C(1);
+    const uint32_t remainder_threshold = remainder_mask >> 1;
+    for (uint32_t i = 0; i < 8; i++) {
+      params.sse2.input_zero_point[i] = (int16_t) (uint16_t) input_zero_point;
+      params.sse2.kernel_zero_point[i] = (int16_t) (uint16_t) kernel_zero_point;
+    }
+    params.sse2.multiplier[0] = multiplier;
+    params.sse2.multiplier[1] = multiplier;
+    params.sse2.multiplier[2] = multiplier;
+    params.sse2.multiplier[3] = multiplier;
+    params.sse2.rounding[0] = UINT64_C(0x40000000);
+    params.sse2.rounding[1] = UINT64_C(0x40000000);
+    params.sse2.remainder_mask[0] = (int32_t) remainder_mask;
+    params.sse2.remainder_mask[1] = (int32_t) remainder_mask;
+    params.sse2.remainder_mask[2] = (int32_t) remainder_mask;
+    params.sse2.remainder_mask[3] = (int32_t) remainder_mask;
+    params.sse2.remainder_threshold[0] = (int32_t) remainder_threshold;
+    params.sse2.remainder_threshold[1] = (int32_t) remainder_threshold;
+    params.sse2.remainder_threshold[2] = (int32_t) remainder_threshold;
+    params.sse2.remainder_threshold[3] = (int32_t) remainder_threshold;
+    params.sse2.shift[0] = (uint64_t) (uint32_t) shift;
+    params.sse2.shift[1] = (uint64_t) (uint32_t) shift;
+    for (uint32_t i = 0; i < 8; i++) {
+      params.sse2.output_zero_point[i] = (int16_t) (uint16_t) output_zero_point;
+    }
+    for (uint32_t i = 0; i < 16; i++) {
+      params.sse2.output_max[i] = output_max;
+      params.sse2.output_min[i] = output_min;
+    }
+  #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+    params.neon.input_zero_point = (int16_t) (uint16_t) input_zero_point;
+    params.neon.kernel_zero_point = (int16_t) (uint16_t) kernel_zero_point;
+    params.neon.multiplier = multiplier;
+    params.neon.right_shift = -shift;
+    params.neon.output_zero_point = (int16_t) (uint16_t) output_zero_point;
+    params.neon.output_max = output_max;
+    params.neon.output_min = output_min;
+    params.neon.kernel_zero_point_v = kernel_zero_point_v;
+    params.neon.multiplier_v = multiplier_v;
+    params.neon.right_shift_v = right_shift_v;
+    for (uint32_t i = 0; i < kernel_params_size; ++i) {
+      const float s = scale_v[i];
+      const uint8_t kzp = kernel_zero_point_v[i];
+      /* Compute requantization parameters */
+      const uint32_t sbits = fp32_to_bits(s);
+      /* Multiplier is in [0x40000000, 0x7FFFFF80] range */
+      const int32_t m = (int32_t)(((sbits & UINT32_C(0x007FFFFF)) | UINT32_C(0x00800000)) << 7);
+      assert(m >= INT32_C(0x40000000));
+      assert(m <= INT32_C(0x7FFFFF80));
+
+      /* Shift is in [0, 31] range */
+      const int32_t rs = 127 + 31 - 32 - (fp32_to_bits(s) >> 23);
+      assert(rs >= 0);
+      assert(rs < 32);
+      params.neon.multiplier_v[i] = m;
+      params.neon.right_shift_v[i] = -rs;
+    }
+
+  #else
+    const uint32_t remainder_mask = (UINT32_C(1) << shift) - UINT32_C(1);
+    const uint32_t remainder_threshold = remainder_mask >> 1;
+    params.scalar.input_zero_point = (int32_t) (uint32_t) input_zero_point;
+    params.scalar.kernel_zero_point = (int32_t) (uint32_t) kernel_zero_point;
+    params.scalar.multiplier = multiplier;
+    params.scalar.remainder_mask = (int32_t) remainder_mask;
+    params.scalar.remainder_threshold = (int32_t) remainder_threshold;
+    params.scalar.shift = (uint32_t) shift;
+    params.scalar.output_min_less_zero_point =
+      (int32_t) (uint32_t) output_min - (int32_t) (uint32_t) output_zero_point;
+    params.scalar.output_max_less_zero_point =
+      (int32_t) (uint32_t) output_max - (int32_t) (uint32_t) output_zero_point;
+    params.scalar.output_zero_point = (int32_t) (uint32_t) output_zero_point;
+  #endif
+  return params;
+}
+
 static inline union qnnp_avgpool_quantization_params qnnp_compute_avgpool_quantization_params(
   int32_t bias,
   float scale,

--- a/test/convolution-operator-tester.h
+++ b/test/convolution-operator-tester.h
@@ -348,15 +348,19 @@ class ConvolutionOperatorTester {
     auto s32rng = std::bind(std::uniform_int_distribution<int32_t>(-10000, 10000), rng);
     auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
 
-    std::vector<uint8_t> input(batchSize() * ((inputHeight() * inputWidth() - 1) * inputPixelStride() + groups() * groupInputChannels()) + 8);
-    std::vector<uint8_t> kernel(groups() * groupOutputChannels() * kernelHeight() * kernelWidth() * groupInputChannels());
+    std::vector<uint8_t> input(
+        batchSize() * ((inputHeight() * inputWidth() - 1) * inputPixelStride() + groups() * groupInputChannels()) + 8);
+    std::vector<uint8_t> kernel(
+        groups() * groupOutputChannels() * kernelHeight() * kernelWidth() * groupInputChannels());
     std::vector<int32_t> bias(groups() * groupOutputChannels());
-    std::vector<uint8_t> output(batchSize() * ((outputHeight() * outputWidth() - 1) * outputPixelStride() + groups() * groupOutputChannels()));
+    std::vector<uint8_t> output(
+        batchSize() * ((outputHeight() * outputWidth() - 1) * outputPixelStride() + groups() * groupOutputChannels()));
     std::vector<int32_t> accumulators(batchSize() * outputHeight() * outputWidth() * groups() * groupOutputChannels());
 
     const uint8_t* inputPtr = input.data() + 8;
     const uint8_t inputZeroPoint = 127;
     const uint8_t kernelZeroPoint = 127;
+    const float kernelScale = 1.0f;
 
     for (size_t iteration = 0; iteration < iterations(); iteration++) {
       std::generate(input.begin(), input.end(), std::ref(u8rng));
@@ -370,8 +374,9 @@ class ConvolutionOperatorTester {
           for (size_t ox = 0; ox < outputWidth(); ox++) {
             for (size_t g = 0; g < groups(); g++) {
               for (size_t oc = 0; oc < groupOutputChannels(); oc++) {
-                accumulators[(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) * groupOutputChannels() + oc] =
-                  bias[g * groupOutputChannels() + oc];
+                accumulators
+                    [(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) * groupOutputChannels() + oc] =
+                        bias[g * groupOutputChannels() + oc];
               }
             }
           }
@@ -389,9 +394,20 @@ class ConvolutionOperatorTester {
                     for (size_t g = 0; g < groups(); g++) {
                       for (size_t oc = 0; oc < groupOutputChannels(); oc++) {
                         for (size_t ic = 0; ic < groupInputChannels(); ic++) {
-                          accumulators[(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) * groupOutputChannels() + oc] +=
-                            (int32_t(inputPtr[((i * inputHeight() + iy) * inputWidth() + ix) * inputPixelStride() + g * groupInputChannels() + ic]) - int32_t(inputZeroPoint)) *
-                            (int32_t(kernel[(((g * groupOutputChannels() + oc) * kernelHeight() + ky) * kernelWidth() + kx) * groupInputChannels() + ic]) - int32_t(kernelZeroPoint));
+                          accumulators
+                              [(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) *
+                                   groupOutputChannels() +
+                               oc] +=
+                              (int32_t(inputPtr
+                                           [((i * inputHeight() + iy) * inputWidth() + ix) * inputPixelStride() +
+                                            g * groupInputChannels() + ic]) -
+                               int32_t(inputZeroPoint)) *
+                              (int32_t(kernel
+                                           [(((g * groupOutputChannels() + oc) * kernelHeight() + ky) * kernelWidth() +
+                                             kx) *
+                                                groupInputChannels() +
+                                            ic]) -
+                               int32_t(kernelZeroPoint));
                         }
                       }
                     }
@@ -406,44 +422,60 @@ class ConvolutionOperatorTester {
       const int32_t accumulatorsMax = *std::max_element(accumulators.cbegin(), accumulators.cend());
 
       const double outputScale = double(uint32_t(accumulatorsMax - accumulatorsMin)) / 255.0;
-      const uint8_t outputZeroPoint = uint8_t(std::max(std::min(
-        lrint(127.5 - 0.5 * double(accumulatorsMin + accumulatorsMax) / outputScale),
-        long(std::numeric_limits<uint8_t>::max())), long(std::numeric_limits<uint8_t>::min())));
+      const uint8_t outputZeroPoint = uint8_t(std::max(
+          std::min(
+              lrint(127.5 - 0.5 * double(accumulatorsMin + accumulatorsMax) / outputScale),
+              long(std::numeric_limits<uint8_t>::max())),
+          long(std::numeric_limits<uint8_t>::min())));
 
       ASSERT_EQ(qnnp_status_success, qnnp_initialize());
       qnnp_operator_t convolution = nullptr;
 
+      ASSERT_EQ(
+          qnnp_status_success,
+          qnnp_create_convolution2d_nhwc_q8(
+              paddingTop(),
+              paddingRight(),
+              paddingBottom(),
+              paddingLeft(),
+              kernelHeight(),
+              kernelWidth(),
+              subsamplingHeight(),
+              subsamplingWidth(),
+              dilationHeight(),
+              dilationWidth(),
+              groups(),
+              groupInputChannels(),
+              groupOutputChannels(),
+              inputZeroPoint,
+              1.0f /* input scale */,
+              kernelZeroPoint,
+              kernelScale,
+              kernel.data(),
+              bias.data(),
+              outputZeroPoint,
+              outputScale,
+              qmin(),
+              qmax(),
+              0,
+              &convolution));
 
-      ASSERT_EQ(qnnp_status_success,
-        qnnp_create_convolution2d_nhwc_q8(
-          paddingTop(), paddingRight(), paddingBottom(), paddingLeft(),
-          kernelHeight(), kernelWidth(),
-          subsamplingHeight(), subsamplingWidth(),
-          dilationHeight(), dilationWidth(),
-          groups(), groupInputChannels(), groupOutputChannels(),
-          inputZeroPoint, 1.0f /* input scale */,
-          kernelZeroPoint, 1.0f /* kernel scale */,
-          kernel.data(), bias.data(),
-          outputZeroPoint, outputScale, qmin(), qmax(),
-          0, &convolution));
+      ASSERT_EQ(
+          qnnp_status_success,
+          qnnp_setup_convolution2d_nhwc_q8(
+              convolution,
+              batchSize(),
+              inputHeight(),
+              inputWidth(),
+              inputPtr,
+              inputPixelStride(),
+              output.data(),
+              outputPixelStride(),
+              nullptr /* thread pool */));
 
-      ASSERT_EQ(qnnp_status_success,
-        qnnp_setup_convolution2d_nhwc_q8(
-          convolution,
-          batchSize(),
-          inputHeight(),
-          inputWidth(),
-          inputPtr,
-          inputPixelStride(),
-          output.data(),
-          outputPixelStride(),
-          nullptr /* thread pool */));
+      ASSERT_EQ(qnnp_status_success, qnnp_run_operator(convolution, nullptr /* thread pool */));
 
-      ASSERT_EQ(qnnp_status_success,
-        qnnp_run_operator(convolution, nullptr /* thread pool */));
-
-      ASSERT_EQ(qnnp_status_success,
-        qnnp_delete_operator(convolution));
+      ASSERT_EQ(qnnp_status_success, qnnp_delete_operator(convolution));
       convolution = nullptr;
 
       for (size_t i = 0; i < batchSize(); i++) {
@@ -452,14 +484,188 @@ class ConvolutionOperatorTester {
             for (size_t g = 0; g < groups(); g++) {
               for (size_t c = 0; c < groupOutputChannels(); c++) {
                 const double scaledAccumulator =
-                  accumulators[(((i * outputHeight() + y) * outputWidth() + x) * groups() + g) * groupOutputChannels() + c] / outputScale;
-                const double clampedAccumulator = std::max(std::min(scaledAccumulator,
-                  double(qmax()) - double(outputZeroPoint)),
-                  double(qmin()) - double(outputZeroPoint));
+                    accumulators
+                        [(((i * outputHeight() + y) * outputWidth() + x) * groups() + g) * groupOutputChannels() + c] *
+                    kernelScale / outputScale;
+                const double clampedAccumulator = std::max(
+                    std::min(scaledAccumulator, double(qmax()) - double(outputZeroPoint)),
+                    double(qmin()) - double(outputZeroPoint));
                 ASSERT_NEAR(
-                  clampedAccumulator,
-                  (int32_t(output[((i * outputHeight() + y) * outputWidth() + x) * outputPixelStride() + g * groupOutputChannels() + c]) - outputZeroPoint),
-                  0.9) << "(x, y) = (" << x << ", " << y << "), group = " << g << ", channel = " << c;
+                    clampedAccumulator,
+                    (int32_t(output
+                                 [((i * outputHeight() + y) * outputWidth() + x) * outputPixelStride() +
+                                  g * groupOutputChannels() + c]) -
+                     outputZeroPoint),
+                    0.9)
+                    << "(x, y) = (" << x << ", " << y << "), group = " << g << ", channel = " << c;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void testQ8_perChannel() const {
+    std::random_device randomDevice;
+    auto rng = std::mt19937(randomDevice());
+    auto s32rng = std::bind(std::uniform_int_distribution<int32_t>(-10000, 10000), rng);
+    auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
+
+    std::vector<uint8_t> input(
+        batchSize() * ((inputHeight() * inputWidth() - 1) * inputPixelStride() + groups() * groupInputChannels()) + 8);
+    std::vector<uint8_t> kernel(
+        groups() * groupOutputChannels() * kernelHeight() * kernelWidth() * groupInputChannels());
+    std::vector<int32_t> bias(groups() * groupOutputChannels());
+    std::vector<uint8_t> output(
+        batchSize() * ((outputHeight() * outputWidth() - 1) * outputPixelStride() + groups() * groupOutputChannels()));
+    std::vector<int32_t> accumulators(batchSize() * outputHeight() * outputWidth() * groups() * groupOutputChannels());
+
+    const uint8_t* inputPtr = input.data() + 8;
+    const uint8_t inputZeroPoint = 127;
+    const uint8_t kernelZeroPointFixed = 127;
+    const float kernelScaleFixed = 1.0f;
+    std::vector<float> kernelScale(groups() * groupOutputChannels());
+    std::vector<uint8_t> kernelZeroPoint(groups() * groupOutputChannels());
+    std::fill(kernelScale.begin(), kernelScale.end(), kernelScaleFixed);
+    std::fill(kernelZeroPoint.begin(), kernelZeroPoint.end(), kernelZeroPointFixed);
+
+    for (size_t iteration = 0; iteration < iterations(); iteration++) {
+      std::generate(input.begin(), input.end(), std::ref(u8rng));
+      std::generate(kernel.begin(), kernel.end(), std::ref(u8rng));
+      std::generate(bias.begin(), bias.end(), std::ref(s32rng));
+      std::fill(output.begin(), output.end(), 0xA5);
+      std::fill(accumulators.begin(), accumulators.end(), 0);
+
+      for (size_t i = 0; i < batchSize(); i++) {
+        for (size_t oy = 0; oy < outputHeight(); oy++) {
+          for (size_t ox = 0; ox < outputWidth(); ox++) {
+            for (size_t g = 0; g < groups(); g++) {
+              for (size_t oc = 0; oc < groupOutputChannels(); oc++) {
+                accumulators
+                    [(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) * groupOutputChannels() + oc] =
+                        bias[g * groupOutputChannels() + oc];
+              }
+            }
+          }
+        }
+      }
+      for (size_t i = 0; i < batchSize(); i++) {
+        for (size_t oy = 0; oy < outputHeight(); oy++) {
+          for (size_t ox = 0; ox < outputWidth(); ox++) {
+            for (size_t ky = 0; ky < kernelHeight(); ky++) {
+              const size_t iy = oy * subsamplingHeight() + ky * dilationHeight() - paddingTop();
+              if (iy < inputHeight()) {
+                for (size_t kx = 0; kx < kernelWidth(); kx++) {
+                  const size_t ix = ox * subsamplingWidth() + kx * dilationWidth() - paddingLeft();
+                  if (ix < inputWidth()) {
+                    for (size_t g = 0; g < groups(); g++) {
+                      for (size_t oc = 0; oc < groupOutputChannels(); oc++) {
+                        for (size_t ic = 0; ic < groupInputChannels(); ic++) {
+                          accumulators
+                              [(((i * outputHeight() + oy) * outputWidth() + ox) * groups() + g) *
+                                   groupOutputChannels() +
+                               oc] +=
+                              (int32_t(inputPtr
+                                           [((i * inputHeight() + iy) * inputWidth() + ix) * inputPixelStride() +
+                                            g * groupInputChannels() + ic]) -
+                               int32_t(inputZeroPoint)) *
+                              (int32_t(kernel
+                                           [(((g * groupOutputChannels() + oc) * kernelHeight() + ky) * kernelWidth() +
+                                             kx) *
+                                                groupInputChannels() +
+                                            ic]) -
+                               int32_t(kernelZeroPoint[g * groupOutputChannels() + oc]));
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      const int32_t accumulatorsMin = *std::min_element(accumulators.cbegin(), accumulators.cend());
+      const int32_t accumulatorsMax = *std::max_element(accumulators.cbegin(), accumulators.cend());
+
+      const double outputScale = double(uint32_t(accumulatorsMax - accumulatorsMin)) / 255.0;
+      const uint8_t outputZeroPoint = uint8_t(std::max(
+          std::min(
+              lrint(127.5 - 0.5 * double(accumulatorsMin + accumulatorsMax) / outputScale),
+              long(std::numeric_limits<uint8_t>::max())),
+          long(std::numeric_limits<uint8_t>::min())));
+
+      ASSERT_EQ(qnnp_status_success, qnnp_initialize());
+      qnnp_operator_t convolution = nullptr;
+
+      ASSERT_EQ(
+          qnnp_status_success,
+          qnnp_create_convolution2d_nhwc_q8(
+              paddingTop(),
+              paddingRight(),
+              paddingBottom(),
+              paddingLeft(),
+              kernelHeight(),
+              kernelWidth(),
+              subsamplingHeight(),
+              subsamplingWidth(),
+              dilationHeight(),
+              dilationWidth(),
+              groups(),
+              groupInputChannels(),
+              groupOutputChannels(),
+              inputZeroPoint,
+              1.0f /* input scale */,
+              kernelZeroPointFixed,
+              kernelScaleFixed,
+              kernel.data(),
+              bias.data(),
+              outputZeroPoint,
+              outputScale,
+              qmin(),
+              qmax(),
+              0,
+              &convolution));
+
+      ASSERT_EQ(
+          qnnp_status_success,
+          qnnp_setup_convolution2d_nhwc_q8(
+              convolution,
+              batchSize(),
+              inputHeight(),
+              inputWidth(),
+              inputPtr,
+              inputPixelStride(),
+              output.data(),
+              outputPixelStride(),
+              nullptr /* thread pool */));
+
+      ASSERT_EQ(qnnp_status_success, qnnp_run_operator(convolution, nullptr /* thread pool */));
+
+      ASSERT_EQ(qnnp_status_success, qnnp_delete_operator(convolution));
+      convolution = nullptr;
+
+      for (size_t i = 0; i < batchSize(); i++) {
+        for (size_t y = 0; y < outputHeight(); y++) {
+          for (size_t x = 0; x < outputWidth(); x++) {
+            for (size_t g = 0; g < groups(); g++) {
+              for (size_t c = 0; c < groupOutputChannels(); c++) {
+                const double scaledAccumulator =
+                    accumulators
+                        [(((i * outputHeight() + y) * outputWidth() + x) * groups() + g) * groupOutputChannels() + c] *
+                    kernelScale[g * groupOutputChannels() + c] / outputScale;
+                const double clampedAccumulator = std::max(
+                    std::min(scaledAccumulator, double(qmax()) - double(outputZeroPoint)),
+                    double(qmin()) - double(outputZeroPoint));
+                ASSERT_NEAR(
+                    clampedAccumulator,
+                    (int32_t(output
+                                 [((i * outputHeight() + y) * outputWidth() + x) * outputPixelStride() +
+                                  g * groupOutputChannels() + c]) -
+                     outputZeroPoint),
+                    0.9)
+                    << "(x, y) = (" << x << ", " << y << "), group = " << g << ", channel = " << c;
               }
             }
           }

--- a/test/gemm-microkernel-tester.h
+++ b/test/gemm-microkernel-tester.h
@@ -948,5 +948,5 @@ class GemmMicrokernelTester {
   uint8_t bZeroPoint_{127};
   uint8_t qmin_{0};
   uint8_t qmax_{255};
-  size_t iterations_{1};
+  size_t iterations_{15};
 };

--- a/test/gemm-microkernel-tester.h
+++ b/test/gemm-microkernel-tester.h
@@ -275,6 +275,128 @@ class GemmMicrokernelTester {
     }
   }
 
+  void test(q8gemm_per_channel_ukernel_function qgemm) const {
+    ASSERT_LE(m(), mr());
+    ASSERT_LE(n(), nr());
+    ASSERT_GE(k(), kr());
+
+    std::random_device randomDevice;
+    auto rng = std::mt19937(randomDevice());
+    auto s32rng = std::bind(std::uniform_int_distribution<int32_t>(-10000, 10000), rng);
+    auto u8rng = std::bind(std::uniform_int_distribution<uint8_t>(), rng);
+
+    std::vector<uint8_t> a((m() - 1) * aStride() + k() + 8);
+    std::vector<uint8_t> b(n() * k());
+    std::vector<int32_t> bias(n());
+    std::vector<uint8_t, AlignedAllocator<uint8_t, 32>> packedW(packedN() * packedK() + biasN() * sizeof(uint32_t) / sizeof(uint8_t));
+    std::vector<uint8_t> c((m() - 1) * cStride() + n());
+    std::vector<int32_t> acc(m() * n());
+    std::vector<uint8_t> cRef(m() * n());
+
+    // Per-Channel quantization parameters
+    std::vector<uint8_t> kernelZeroPointPerChannel(nr());
+    std::vector<float> kernelAndInputScalePerChannel(nr());
+    std::vector<float> requantizationScalePerChannel(nr());
+    std::vector<int32_t> multiplierPerChannel(nr());
+    std::vector<int32_t> rightShiftPerChannel(nr());
+
+    // 1) Fill zero-point per-channel around bZeroPoint() as center value.
+    // 2) Fill kernel-and-input per-channel using linear interpolation between min and max values.
+    //    (Maintain: requantization_scale < 1 ;
+    //               requantization_scale := input_scale * kernel_scale / output_scale)
+    const float scale_min = 0.5f;
+    const float scale_max = 0.99999f;
+    for (size_t i = 0; i < nr(); ++i) {
+      kernelZeroPointPerChannel[i] =
+        static_cast<uint8_t>(std::min(255, std::max(0, bZeroPoint() + (int)(i - nr()/2))));
+      kernelAndInputScalePerChannel[i] = scale_min + i * (scale_max -  scale_min) / nr();
+    }
+
+    const uint8_t* aPtr = a.data() + 8;
+
+    for (size_t iteration = 0; iteration < iterations(); iteration++) {
+      std::generate(a.begin(), a.end(), std::ref(u8rng));
+      std::generate(b.begin(), b.end(), std::ref(u8rng));
+      std::generate(bias.begin(), bias.end(), std::ref(s32rng));
+      std::fill(c.begin(), c.end(), 0xA5);
+
+      std::fill(packedW.begin(), packedW.end(), bZeroPoint());
+      pack_q8gemm_w_per_channel(n(), k(),
+        nr(), np(), kr(),
+        aZeroPoint(), kernelZeroPointPerChannel.data(),
+        b.data(), bias.data(), packedW.data());
+
+      ASSERT_NE(*std::max_element(a.cbegin(), a.cend()), *std::min_element(a.cbegin(), a.cend()));
+      ASSERT_NE(*std::max_element(b.cbegin(), b.cend()), *std::min_element(b.cbegin(), b.cend()));
+
+      /* Compute 32-bit results and output quantization arguments */
+      std::fill(acc.begin(), acc.end(), 0);
+      for (size_t mIndex = 0; mIndex < m(); mIndex++) {
+        for (size_t nIndex = 0; nIndex < n(); nIndex++) {
+          for (size_t kIndex = 0; kIndex < k(); kIndex++) {
+            ASSERT_LE(n(), packedN());
+            ASSERT_LT(mIndex * n() + nIndex, acc.size());
+            ASSERT_LT(mIndex * k() + kIndex, a.size());
+            acc[mIndex * n() + nIndex] +=
+                (int32_t(aPtr[mIndex * aStride() + kIndex]) - int32_t(aZeroPoint())) *
+                (int32_t(b[nIndex * k() + kIndex]) - int32_t(kernelZeroPointPerChannel[nIndex]));
+          }
+          acc[mIndex * n() + nIndex] += bias[nIndex];
+        }
+      }
+
+      const int32_t accMin = *std::min_element(acc.cbegin(), acc.cend());
+      const int32_t accMax = *std::max_element(acc.cbegin(), acc.cend());
+      if (m() * n() >= 3) {
+        ASSERT_NE(accMax, accMin)
+            << "Mr x Nr x Kr = " << mr() << " x " << nr() << " x " << kr()
+            << ", M x N x K = " << m() << " x " << n() << " x " << k();
+      }
+
+      const double cScale = uint32_t(accMax - accMin) >= 256 ? double(uint32_t(accMax - accMin)) / 255.0 : 1.00001;
+      const uint8_t cZeroPoint = uint8_t(std::max(std::min(
+        lrint(127.5 - 0.5 * double(accMin + accMax) / cScale),
+        long(std::numeric_limits<uint8_t>::max())), long(std::numeric_limits<uint8_t>::min())));
+
+      for (size_t nIndex = 0; nIndex < nr(); nIndex++) {
+        requantizationScalePerChannel[nIndex] = kernelAndInputScalePerChannel[nIndex] / float(cScale);
+      }
+      const union qnnp_conv_quantization_params quantizationParams =
+        qnnp_compute_conv_quantization_params_per_channel(
+          aZeroPoint(), nr(), kernelZeroPointPerChannel.data(),
+          requantizationScalePerChannel.data(), multiplierPerChannel.data(), rightShiftPerChannel.data(),  cZeroPoint, qmin(), qmax());
+
+      qgemm(
+        m(), n(), k(),
+        aPtr, aStride() * sizeof(uint8_t),
+        packedW.data(),
+        c.data(), cStride() * sizeof(uint8_t),
+        &quantizationParams, 0);
+
+      for (size_t mIndex = 0; mIndex < m(); mIndex++) {
+        for (size_t nIndex = 0; nIndex < n(); nIndex++) {
+          const union qnnp_q31_requantization_params scalarRequantizationParams =
+            qnnp_compute_scalar_requantization_params(
+              requantizationScalePerChannel[nIndex], cZeroPoint, qmin(), qmax());
+          cRef[mIndex * n() + nIndex] = qnnp_q31_requantize(acc[mIndex * n() + nIndex], scalarRequantizationParams);
+        }
+      }
+
+      for (size_t mIndex = 0; mIndex < m(); mIndex++) {
+        for (size_t nIndex = 0; nIndex < n(); nIndex++) {
+          ASSERT_LE(uint32_t(c[mIndex * cStride() + nIndex]), uint32_t(qmax()));
+          ASSERT_GE(uint32_t(c[mIndex * cStride() + nIndex]), uint32_t(qmin()));
+          ASSERT_EQ(uint32_t(c[mIndex * cStride() + nIndex]), uint32_t(cRef[mIndex * n() + nIndex]))
+              << "at " << mIndex << ", " << nIndex << ": reference = " << (uint32_t) cRef[mIndex * n() + nIndex]
+              << " (accumulator = " << acc[mIndex * n() + nIndex]
+              << "), optimized = " << (uint32_t) c[mIndex * cStride() + nIndex] << ", Mr x Nr x Kr = " << mr() << " x "
+              << nr() << " x " << kr() << ", M x N x K = " << m() << " x " << n() << " x " << k()
+              << ", requantization scale = " << requantizationScalePerChannel[nIndex] << ", output zero point = " << int32_t(cZeroPoint);
+        }
+      }
+    }
+  }
+
   void test(q8conv_ukernel_function qconv) const {
     ASSERT_LE(m(), mr());
     ASSERT_LE(n(), nr());
@@ -826,5 +948,5 @@ class GemmMicrokernelTester {
   uint8_t bZeroPoint_{127};
   uint8_t qmin_{0};
   uint8_t qmax_{255};
-  size_t iterations_{15};
+  size_t iterations_{1};
 };

--- a/test/q8gemm.cc
+++ b/test/q8gemm.cc
@@ -14,7 +14,6 @@
 
 #include "gemm-microkernel-tester.h"
 
-
 #if CPUINFO_ARCH_ARM
   TEST(Q8GEMM_4x8__AARCH32_NEON, k_eq_8) {
     TEST_REQUIRES_ARM_NEON;
@@ -2060,6 +2059,301 @@
             .k(k)
             .iterations(3)
             .test(q8gemm_xzp_ukernel_4x8c2__neon);
+        }
+      }
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_a_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .aStride(37)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_strided_c_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .cStride(17)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_qmin128_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .qmin(128)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_qmax128_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .qmax(128)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_azp0_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .aZeroPoint(0)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_bzp0_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .bZeroPoint(0)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_eq_8_nozp_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    GemmMicrokernelTester()
+      .mr(4)
+      .nr(8)
+      .np(8)
+      .kr(1)
+      .m(4)
+      .n(8)
+      .k(8)
+      .aZeroPoint(0)
+      .bZeroPoint(0)
+      .test(q8gemm_per_channel_ukernel_4x8__neon);
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_strided_a_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .aStride(37)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_strided_c_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .cStride(17)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_azp0_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .aZeroPoint(0)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_bzp0_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .bZeroPoint(0)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_nozp_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .aZeroPoint(0)
+        .bZeroPoint(0)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_gt_8_subtile_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 9; k < 16; k++) {
+      for (uint32_t m = 1; m <= 4; m++) {
+        for (uint32_t n = 1; n <= 8; n++) {
+          GemmMicrokernelTester()
+            .mr(4)
+            .nr(8)
+            .np(8)
+            .kr(1)
+            .m(m)
+            .n(n)
+            .k(k)
+            .iterations(3)
+            .test(q8gemm_per_channel_ukernel_4x8__neon);
+        }
+      }
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_div_8_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 16; k < 128; k += 8) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_div_8_strided_a_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 16; k < 128; k += 8) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .aStride(171)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_div_8_strided_c_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 16; k < 128; k += 8) {
+      GemmMicrokernelTester()
+        .mr(4)
+        .nr(8)
+        .np(8)
+        .kr(1)
+        .m(4)
+        .n(8)
+        .k(k)
+        .cStride(17)
+        .test(q8gemm_per_channel_ukernel_4x8__neon);
+    }
+  }
+
+  TEST(Q8GEMM_4x8__NEON, k_div_8_subtile_per_channel) {
+    TEST_REQUIRES_ARM_NEON;
+    for (size_t k = 16; k < 128; k += 24) {
+      for (uint32_t m = 1; m <= 4; m++) {
+        for (uint32_t n = 1; n <= 8; n++) {
+          GemmMicrokernelTester()
+            .mr(4)
+            .nr(8)
+            .np(8)
+            .kr(1)
+            .m(m)
+            .n(n)
+            .k(k)
+            .iterations(3)
+            .test(q8gemm_per_channel_ukernel_4x8__neon);
         }
       }
     }


### PR DESCRIPTION
This is a preliminary version in order to get some feedback.
The goal is adding support in GEMM with different kernel quantization parameters per output channel.

Changes:
* Modified version of 4x8 gemm ukernel was added, to support kernel scale and zero-point per output channel.
* Helper funcitons were added : weights-packing, computing requantization parameters
* gemm-micro-kernel test function was added with corresponding unit-tests 