### PR TITLE
Remove IGNORE_CODE_ALIGN_DIRECTIVES from aarch32 code

### DIFF
--- a/src/hgemm/8x8-aarch32-neonfp16arith.S
+++ b/src/hgemm/8x8-aarch32-neonfp16arith.S
@@ -94,9 +94,7 @@ BEGIN_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
 	SUBS r2, r2, 4
 	BLO 1f
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 5
-#endif
 0:
 	# Load a0
 	# - d0 = a0
@@ -355,9 +353,7 @@ BEGIN_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
 	# vacc7x01234567 += vb01234567 * va7[2];
 	.word 0xF3DCE167 @ VMLA.F16 q15, q6, d7[2]
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 4
-#endif
 2:
 	# Load params:
 	# - ip = params
@@ -445,9 +441,7 @@ BEGIN_FUNCTION hgemm_ukernel_8x8__aarch32_neonfp16arith
 	POP {r4, r5, r6, r7, r8, r9, r10, r11}
 	BX lr
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 3
-#endif
 4:
 	CMP r1, 4
 	BLO 5f

--- a/src/q8conv/4x8-aarch32-neon.S
+++ b/src/q8conv/4x8-aarch32-neon.S
@@ -62,9 +62,7 @@ BEGIN_FUNCTION q8conv_ukernel_4x8__aarch32_neon
 	# - d12 = vmultiplier
 	VLD1.32 {d12[]}, [r9]!
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 5
-#endif
 0:
 	SUBS r10, r2, 8
 
@@ -630,9 +628,7 @@ BEGIN_FUNCTION q8conv_ukernel_4x8__aarch32_neon
 	# vacc3x4567 += vb4567 * va3[6]
 	VMLAL.S16 q15, d9, d7[2]
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 4
-#endif
 3:
 	SUBS r3, r3, 1
 	BNE 0b
@@ -746,9 +742,7 @@ BEGIN_FUNCTION q8conv_ukernel_4x8__aarch32_neon
 	POP {r4, r5, r6, r7, r8, r9, r10, r11}
 	BX lr
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 3
-#endif
 5:
 	CMP r1, 4
 	BLO 6f

--- a/src/q8dwconv/up8x9-aarch32-neon.S
+++ b/src/q8dwconv/up8x9-aarch32-neon.S
@@ -70,9 +70,7 @@ BEGIN_FUNCTION q8dwconv_ukernel_up8x9__aarch32_neon
 	# - d21 = voutput_min
 	VLD1.8 {d21[]}, [r12]
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 3
-#endif
 0:
 	# Load input stride
 	# - r3 = input_stride
@@ -107,9 +105,7 @@ BEGIN_FUNCTION q8dwconv_ukernel_up8x9__aarch32_neon
 
 	BLO 2f
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 4
-#endif
 1:
 	VLDM r3!, {d0-d3}
 

--- a/src/q8gemm/4x8-aarch32-neon.S
+++ b/src/q8gemm/4x8-aarch32-neon.S
@@ -76,9 +76,7 @@ BEGIN_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
 	VLD1.32 {d12[]}, [r7]!
 	BLO 1f
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 5
-#endif
 0:
 	# Load a0
 	# - d1 = a0
@@ -632,9 +630,7 @@ BEGIN_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
 	# vacc3x4567 += vb4567 * va3[6]
 	VMLAL.S16 q15, d9, d7[2]
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 4
-#endif
 2:
 	# Load right_shift
 	# - q4 = d8:d9 = vright_shift
@@ -745,9 +741,7 @@ BEGIN_FUNCTION q8gemm_ukernel_4x8__aarch32_neon
 	POP {r4, r5, r6, r7}
 	BX lr
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 	.p2align 3
-#endif
 4:
 	CMP r1, 4
 	BLO 5f

--- a/src/q8gemm/4x8c2-xzp-aarch32-neon.S
+++ b/src/q8gemm/4x8c2-xzp-aarch32-neon.S
@@ -142,9 +142,7 @@ BEGIN_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
 
   BLO 1f
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 .p2align 5
-#endif
 0:
   # load a
   # d0 := va0x01234567
@@ -454,9 +452,7 @@ BEGIN_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
   VMULL.U8 q5, d3, d15
   VPADAL.U16 q15, q5
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
   .p2align 4
-#endif
 4:
   # Load params:
   # - ip = params
@@ -575,9 +571,7 @@ BEGIN_FUNCTION q8gemm_xzp_ukernel_4x8c2__aarch32_neon
   POP {r4, r5, r6, r7, r8, r9, r10, r11}
   BX lr
 
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
   .p2align 3
-#endif
 5:
   CMP r1, 4
   BLO 6f

--- a/src/qnnpack/assembly.h
+++ b/src/qnnpack/assembly.h
@@ -10,9 +10,7 @@
 #ifdef __ELF__
 	.macro BEGIN_FUNCTION name
 		.text
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 		.align 2
-#endif		
 		.global \name
 		.type \name, %function
 		\name:
@@ -24,9 +22,7 @@
 #elif defined(__MACH__)
 	.macro BEGIN_FUNCTION name
 		.text
-#ifndef IGNORE_CODE_ALIGN_DIRECTIVES
 		.align 2
-#endif
 		.global _\name
 		.private_extern _\name
 		_\name:


### PR DESCRIPTION
For aarch32, we always need the code alignment instructions, or we will have crashes.