### PR TITLE
Fix clamp operator to work when output_min == output_max.

### DIFF
--- a/src/clamp.c
+++ b/src/clamp.c
@@ -40,7 +40,7 @@ enum qnnp_status qnnp_create_clamp_nc_u8(
     goto error;
   }
 
-  if (output_min >= output_max) {
+  if (output_min > output_max) {
     qnnp_log_error(
       "failed to create Clamp operator with [%" PRIu8 ", %" PRIu8 "] output range: range min must be below range max",
       output_min, output_max);

--- a/src/qnnpack/requantization.h
+++ b/src/qnnpack/requantization.h
@@ -306,7 +306,7 @@ static inline union qnnp_u8_clamping_params qnnp_compute_u8_clamping_params(
   uint8_t output_min,
   uint8_t output_max)
 {
-  assert(output_min < output_max);
+  assert(output_min <= output_max);
 
   union qnnp_u8_clamping_params params;
   #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64

--- a/test/clamp.cc
+++ b/test/clamp.cc
@@ -98,3 +98,15 @@ TEST(CLAMP_OP, small_batch_with_input_and_output_stride) {
       .testU8();
   }
 }
+
+TEST(CLAMP_OP, qmin_and_qmax_equal_uint8_max) {
+  for (size_t channels = 1; channels < 100; channels += 15) {
+    ClampOperatorTester()
+      .batchSize(3)
+      .channels(channels)
+      .qmin(255)
+      .qmax(255)
+      .iterations(3)
+      .testU8();
+  }
+}


### PR DESCRIPTION
Summary:
Clamping should be ideally tightly bound to [output_min, output_min] or [output_max, output_max].
This fails in testing when zero_point is set to 255 which is possible when all values are negative.

Test Plan:
Unit tests

Reviewers:
zaf
Subscribers:

Tasks:

Tags: